### PR TITLE
Use the "masked" code for encrypted resource parts

### DIFF
--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Visitors/AnonymizationVisitorTests.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Visitors/AnonymizationVisitorTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Visitors
 
             patient = patientNode.ToPoco<Patient>();
             Assert.Single(patient.Meta.Security);
-            Assert.Contains(SecurityLabels.ENCRYPT.Code, patient.Meta.Security.Select(s => s.Code));
+            Assert.Contains(SecurityLabels.MASKED.Code, patient.Meta.Security.Select(s => s.Code));
         }
 
         [Fact]
@@ -98,7 +98,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Visitors
             AnonymizationFhirPathRule[] rules = new AnonymizationFhirPathRule[]
             {
                 new AnonymizationFhirPathRule("Patient.address.city", "address.city", "Patient", "substitute", AnonymizerRuleType.FhirPathRule, "Patient.address.city",
-                    new Dictionary<string, object> { {"replaceWith", "ExampleCity2020" } })           
+                    new Dictionary<string, object> { {"replaceWith", "ExampleCity2020" } })
             };
 
             AnonymizationVisitor visitor = new AnonymizationVisitor(rules, CreateTestProcessors());
@@ -275,7 +275,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Visitors
 
             var patient = CreateTestPatient();
             var patientNode = ElementNode.FromElement(patient.ToTypedElement());
-            patientNode.Accept(visitor); 
+            patientNode.Accept(visitor);
             string patientCity = patientNode.Select("Patient.address[0].city").First().Value.ToString();
             string patientCountry = patientNode.Select("Patient.address[0].country").First().Value.ToString();
 

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Models/SecurityLabels.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Models/SecurityLabels.cs
@@ -25,10 +25,11 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Models
             Display = "cryptographic hash function"
         };
 
-        public static readonly Coding ENCRYPT = new Coding()
+        public static readonly Coding MASKED = new Coding()
         {
-            Code = "ENCRYPT",
-            Display = "exact value is transformed into ciphertext"
+            System = "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+            Code = "MASKED",
+            Display = "masked"
         };
 
         public static readonly Coding PERTURBED = new Coding()

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Processors/ResourceProcessor.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Processors/ResourceProcessor.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Processors
         private readonly HashSet<ElementNode> _visitedNodes = new HashSet<ElementNode>();
         private readonly Dictionary<string, List<ITypedElement>> _typeToNodeLookUp = new Dictionary<string, List<ITypedElement>>();
         private readonly Dictionary<string, List<ITypedElement>> _nameToNodeLookUp = new Dictionary<string, List<ITypedElement>>();
-        
+
         private static readonly PocoStructureDefinitionSummaryProvider s_provider = new PocoStructureDefinitionSummaryProvider();
         private const string _metaNodeName = "meta";
 
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Processors
                 }
 
                 var matchNodes = GetMatchNodes(rule, node);
-                
+
                 foreach (var matchNode in matchNodes)
                 {
                     ruleResult.Update(ProcessNodeRecursive((ElementNode) matchNode.ToElement(), _processors[method], ruleContext, rule.RuleSettings));
@@ -97,9 +97,9 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Processors
             }
 
             if (result.IsEncrypted && !meta.Security.Any(x =>
-                string.Equals(x.Code, SecurityLabels.ENCRYPT.Code, StringComparison.InvariantCultureIgnoreCase)))
+                string.Equals(x.Code, SecurityLabels.MASKED.Code, StringComparison.InvariantCultureIgnoreCase)))
             {
-                meta.Security.Add(SecurityLabels.ENCRYPT);
+                meta.Security.Add(SecurityLabels.MASKED);
             }
 
             if (result.IsPerturbed && !meta.Security.Any(x =>
@@ -196,9 +196,9 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Processors
 
             /*
             * Special case handling:
-            * Senario: FHIR path only contains resourceType: Patient, Resource. 
+            * Senario: FHIR path only contains resourceType: Patient, Resource.
             * Sample AnonymizationFhirPathRule: { "path": "Patient", "method": "keep" }
-            * 
+            *
             * Current FHIR path lib do not support navigate such ResourceType FHIR path from resource in bundle.
             * Example: navigate with FHIR path "Patient" from "Bundle.entry[0].resource[0]" is not support
             */


### PR DESCRIPTION
Closes #95