### PR TITLE
Fix issue whereby the Azure Data Factory is always deployed to WestUs

### DIFF
--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.AzureDataFactoryPipeline/scripts/ArmTemplate/arm_template.json
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.AzureDataFactoryPipeline/scripts/ArmTemplate/arm_template.json
@@ -77,7 +77,7 @@
             "type": "Microsoft.DataFactory/factories",
             "apiVersion": "2018-06-01",
             "name": "[parameters('factoryName')]",
-            "location": "WestUs",
+            "location": "[parameters('location')]",
             "tags": {
                 "FHIRAnonymizer": "[parameters('solutionName')]"
             },


### PR DESCRIPTION
Currently, the de-identification ADF is always deployed to `WestUs` instead of the location configured in parameters.  This breaks deployment for us because our institutional policies forbid deployment in `WestUs`.

This simple change fixes the issue by using the configured `location` parameter to deploy the ADF instead.