### PR TITLE
Adds "ignoreinvalid" configuration option

### DIFF
--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.AzureDataFactoryPipeline/src/DataFactoryCustomActivity.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.AzureDataFactoryPipeline/src/DataFactoryCustomActivity.cs
@@ -231,6 +231,11 @@ namespace Microsoft.Health.Fhir.Anonymizer.DataFactoryTool
             };
 
             await executor.ExecuteAsync(CancellationToken.None, progress).ConfigureAwait(false);
+
+            // If nothing was successfully processed, do not write the file.
+            if (processedCount == 0) {
+              await outputBlobClient.DeleteIfExistsAsync().ConfigureAwait(false);
+            }
         }
 
         private string GetBlobPrefixFromFolderPath(string folderPath)

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.CommandLineTool/FilesAnonymizerForJsonFormatResource.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.CommandLineTool/FilesAnonymizerForJsonFormatResource.cs
@@ -101,7 +101,12 @@ namespace Microsoft.Health.Fhir.Anonymizer.Tool
                     ValidateOutput = _options.ValidateOutput
                 };
                 var resourceResult = engine.AnonymizeJson(resourceJson, settings);
-                await File.WriteAllTextAsync(resourceOutputFileName, resourceResult).ConfigureAwait(false);
+                if (resourceResult != string.Empty) {
+                  await File.WriteAllTextAsync(resourceOutputFileName, resourceResult).ConfigureAwait(false);
+                } else {
+                  Console.WriteLine($"Skip processing on file {fileName} due to invalid input.");
+                  return string.Empty;
+                }
                 return resourceResult;
             }
             catch (Exception innerException)

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/AnonymizerConfigurations/ProcessingErrorsOption.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/AnonymizerConfigurations/ProcessingErrorsOption.cs
@@ -4,6 +4,6 @@
     {
         Raise, // Invalid processing will raise an exception.
         Skip,  // Invalid processing will return empty element.
-        // Ignore Invalid processing will return input.
+        IgnoreInvalid, // Ignore Invalid processing will return empty element.
     }
 }

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/AnonymizerEngine.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/AnonymizerEngine.cs
@@ -103,10 +103,12 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core
         {
             EnsureArg.IsNotNullOrEmpty(json, nameof(json));
             ITypedElement element;
+            ITypedElement anonymizedElement;
 
             try
             {
                 element = ParseJsonToTypedElement(json);
+                anonymizedElement = AnonymizeElement(element);
             }
             catch (InvalidInputException) {
                 if(_configurationManager.Configuration.processingErrors == ProcessingErrorsOption.IgnoreInvalid)
@@ -117,8 +119,6 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core
 
                 throw;
             }
-
-            var anonymizedElement = AnonymizeElement(element);
 
             var serializationSettings = new FhirJsonSerializationSettings
             {

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/PartitionedExecution/FhirPartitionedExecutor.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/PartitionedExecution/FhirPartitionedExecutor.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core
                     }
 
                     TResult anonymizedResult = await AnonymizerFunctionAsync(content);
-                    if (EmptyElement.IsEmptyElement(anonymizedResult))
+                    if (EmptyElement.IsEmptyElement(anonymizedResult) || anonymizedResult.ToString() == string.Empty)
                     {
                         batchAnonymizeProgressDetail.ProcessSkipped++;
                     }

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/CollectionResourceTests.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/CollectionResourceTests.cs
@@ -29,6 +29,13 @@ namespace Microsoft.Health.Fhir.Anonymizer.FunctionalTests
         }
 
         [Fact]
+        public void GivenAResourceWithContained_WhenAnonymizingWithBadJsonFile_IfIgnore_EmptyResultWillBeReturned()
+        {
+            AnonymizerEngine engine = new AnonymizerEngine(Path.Combine("Configurations", "configuration-ignoreinvalid-processing-error.json"));
+            FunctionalTestUtility.VerifyEmptyStringFromFile(engine, CollectionResourceTestsFile("invalid-json-resource.json"));
+        }
+
+        [Fact]
         public void GivenAResourceWithContained_WhenAnonymizingWithProcessingError_IfSkip_EmptyResultWillBeReturned()
         {
             AnonymizerEngine engine = new AnonymizerEngine(Path.Combine("Configurations", "configuration-skip-processing-error.json"));

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/CollectionResourceTests.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/CollectionResourceTests.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Health.Fhir.Anonymizer.FunctionalTests
         }
 
         [Fact]
+        public void GivenAResourceWithContained_WhenAnonymizingWithBadFile_IfIgnore_EmptyResultWillBeReturned()
+        {
+            AnonymizerEngine engine = new AnonymizerEngine(Path.Combine("Configurations", "configuration-ignoreinvalid-processing-error.json"));
+            FunctionalTestUtility.VerifyEmptyStringFromFile(engine, CollectionResourceTestsFile("invalid-resource.json"));
+        }
+
+        [Fact]
         public void GivenAResourceWithContained_WhenAnonymizingWithProcessingError_IfSkip_EmptyResultWillBeReturned()
         {
             AnonymizerEngine engine = new AnonymizerEngine(Path.Combine("Configurations", "configuration-skip-processing-error.json"));

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/Configurations/configuration-ignoreinvalid-processing-error.json
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/Configurations/configuration-ignoreinvalid-processing-error.json
@@ -1,0 +1,52 @@
+﻿{
+  "fhirVersion": "",
+  "processingErrors": "ignoreinvalid",
+  "fhirPathRules": [
+    {
+        "path": "nodesByType('HumanName').family",
+        "method": "generalize",
+        "cases": {
+            "$this>=0 and $this<20": "20"
+        }
+    },
+    {
+      "path": "TestResource",
+      "method": "redact"
+    },
+    {
+      "path": "nodesByType('HumanName')",
+      "method": "redact"
+    },
+    {
+      "path": "Resource",
+      "method": "keep"
+    },
+    {
+      "path": "Device.where(id.exists()).id",
+      "method": "keep"
+    }
+  ],
+  "parameters": {
+    "dateShiftKey": "",
+    "cryptoHashKey": "",
+    "enablePartialAgesForRedact": true,
+    "enablePartialDatesForRedact": true,
+    "enablePartialZipCodesForRedact": true,
+    "restrictedZipCodeTabulationAreas": [
+      "036",
+      "059",
+      "102",
+      "203",
+      "205",
+      "369",
+      "556",
+      "692",
+      "821",
+      "823",
+      "878",
+      "879",
+      "884",
+      "893"
+    ]
+  }
+}

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/FunctionalTestUtility.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/FunctionalTestUtility.cs
@@ -18,6 +18,14 @@ namespace Microsoft.Health.Fhir.Anonymizer.FunctionalTests
             Assert.Equal(Standardize(targetContent), Standardize(resultAfterAnonymize));
         } 
 
+        public static void VerifyEmptyStringFromFile(AnonymizerEngine engine, string testFile)
+        {
+            Console.WriteLine($"VerifyEmptyStringFromFile. TestFile: {testFile}");
+            string testContent = File.ReadAllText(testFile);
+            string resultAfterAnonymize = engine.AnonymizeJson(testContent);
+            Assert.Equal(string.Empty, resultAfterAnonymize);
+        }
+
         private static string Standardize(string jsonContent)
         {
             var resource = new FhirJsonParser().Parse<Resource>(jsonContent);

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests.projitems
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests.projitems
@@ -102,6 +102,9 @@
     <None Include="$(MSBuildThisFileDirectory)TestResources\invalid-resource.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="$(MSBuildThisFileDirectory)TestResources\invalid-json-resource.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="$(MSBuildThisFileDirectory)TestResources\patient-generalize-target.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests.projitems
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests.projitems
@@ -18,6 +18,9 @@
     <None Include="$(MSBuildThisFileDirectory)Configurations\configuration-raise-processing-error.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="$(MSBuildThisFileDirectory)Configurations\configuration-ignoreinvalid-processing-error.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="$(MSBuildThisFileDirectory)Configurations\configuration-skip-processing-error.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -94,6 +97,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="$(MSBuildThisFileDirectory)TestResources\contained-redact-all-target.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)TestResources\invalid-resource.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="$(MSBuildThisFileDirectory)TestResources\patient-generalize-target.json">

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/TestResources/invalid-json-resource.json
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/TestResources/invalid-json-resource.json
@@ -1,0 +1,1 @@
+{"resourceType": "Patient", "badField": "NotAField"}

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/TestResources/invalid-resource.json
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.FunctionalTests/TestResources/invalid-resource.json
@@ -1,0 +1,1 @@
+BAD BAD BAD

--- a/docs/FHIR-anonymization.md
+++ b/docs/FHIR-anonymization.md
@@ -253,8 +253,9 @@ Since _AnonymizationProcessingException_ may caused by a specific FHIR resource,
 
 |processingErrors|Description|
 |----|----|
-|raise|Raise _AnonymizationProcessingException_ with program failed and stopped.|
-|skip| Skip _AnonymizationProcessingException_ and return an empty FHIR resource with program continued. |
+|raise|Raise _AnonymizerProcessingException_ with program failed and stopped.|
+|skip| Skip _AnonymizerProcessingException_ and return an empty FHIR resource with program continued. |
+|ignoreinvalid| Skip both _AnonymizerProcessingException_ and _InvalidInputException_ errors, and return an empty FHIR resource with program continued. |
 
 Here is the structure of empty FHIR resource for patient:
 ```


### PR DESCRIPTION
As per #170, this adds an "ignoreinvalid" configuration option that allows skipping of files that do not contain FHIR, contain invalid FHIR or are otherwise corrupt.  Automatic tests are included and this has been manually tested in Azure Data Factory.