### PR TITLE
Update firely sdk version

### DIFF
--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.R4" Version="3.4.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="3.4.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="4.2.1" />
+    <PackageReference Include="Hl7.FhirPath" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core/Microsoft.Health.Fhir.Anonymizer.R4.Core.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core/Microsoft.Health.Fhir.Anonymizer.R4.Core.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="3.4.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="3.4.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="4.2.1" />
+    <PackageReference Include="Hl7.FhirPath" Version="4.2.1" />
     <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.R4" Version="3.4.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="3.4.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="4.2.1" />
+    <PackageReference Include="Hl7.FhirPath" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Validation/AttributeValidatorTests.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Validation/AttributeValidatorTests.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Validation
         private readonly AttributeValidator _validator = new AttributeValidator();
 
         [Theory]
-        [InlineData("1+1")]
-        [InlineData("1_1")]
-        [InlineData("11|")]
-        [InlineData("00000000000000000000000000000000000000000000000000000000000000065")]
-        public void GivenAnInvalidId_WhenValidateAResource_ThenValidationErrorsShouldBeReturned(string id)
+        [InlineData("1+1", "'1+1' is not a correct literal for an id. At Patient.IdElement.Value.")]
+        [InlineData("1_1", "'1_1' is not a correct literal for an id. At Patient.IdElement.Value.")]
+        [InlineData("11|", "'11|' is not a correct literal for an id. At Patient.IdElement.Value.")]
+        [InlineData("00000000000000000000000000000000000000000000000000000000000000065", "'00000000000000000000000000000000000000000000000000000000000000065' is not a correct literal for an id. At Patient.IdElement.Value.")]
+        public void GivenAnInvalidId_WhenValidateAResource_ThenValidationErrorsShouldBeReturned(string id, string expectedError)
         {
             var resource = new Patient
             {
@@ -27,17 +27,16 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Validation
             var validationErrors = _validator.Validate(resource).ToList();
             Assert.Single(validationErrors);
 
-            var expectedError = id + " is not a correctly formatted Id";
             var actualError = validationErrors.FirstOrDefault()?.ErrorMessage;
             Assert.Equal(expectedError, actualError);
         }
 
         [Theory]
-        [InlineData("******")]
-        [InlineData("Should not be valid")]
-        [InlineData("<body>Should not be valid</body>")]
-        [InlineData("<div xmlns='http://www.w3.org/1999/xhtml'><p>should not be valid<p></div>")]
-        public void GivenAnInvalidNarrative_WhenValidateAResource_ThenValidationErrorsShouldBeReturned(string div)
+        [InlineData("******", "Value is not well-formatted Xml: Invalid Xml encountered. Details: Data at the root level is invalid. Line 1, position 1. At Patient.Text.Div.")]
+        [InlineData("Should not be valid", "Value is not well-formatted Xml: Invalid Xml encountered. Details: Data at the root level is invalid. Line 1, position 1. At Patient.Text.Div.")]
+        [InlineData("<body>Should not be valid</body>", "Value is not well-formed Xml adhering to the FHIR schema for Narrative: Root element of XHTML is not a <div> from the XHTML namespace (http://www.w3.org/1999/xhtml). At Patient.Text.Div.")]
+        [InlineData("<div xmlns='http://www.w3.org/1999/xhtml'><p>should not be valid<p></div>", "Value is not well-formatted Xml: Invalid Xml encountered. Details: The 'p' start tag on line 1 position 66 does not match the end tag of 'div'. Line 1, position 70. At Patient.Text.Div.")]
+        public void GivenAnInvalidNarrative_WhenValidateAResource_ThenValidationErrorsShouldBeReturned(string div, string expectedError)
         {
             var resource = new Patient
             {
@@ -51,7 +50,6 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Validation
             var validationErrors = _validator.Validate(resource).ToList();
             Assert.Single(validationErrors);
 
-            var expectedError = "Xml can not be parsed or is not valid according to the (limited) FHIR scheme";
             var actualError = validationErrors.FirstOrDefault()?.ErrorMessage;
             Assert.Equal(expectedError, actualError);
         }
@@ -68,7 +66,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Validation
             var validationErrors = _validator.Validate(resource).ToList();
             Assert.Single(validationErrors);
 
-            var expectedError = "Element with min. cardinality 1 cannot be null";
+            var expectedError = "Element with minimum cardinality 1 cannot be null. At Task.IntentElement.";
             var actualError = validationErrors.FirstOrDefault()?.ErrorMessage;
             Assert.Equal(expectedError, actualError);
 

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests.csproj
@@ -11,8 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="3.4.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="3.4.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="4.2.1" />
+    <PackageReference Include="Hl7.FhirPath" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.STU3" Version="3.4.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="3.4.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="4.2.1" />
+    <PackageReference Include="Hl7.FhirPath" Version="4.2.1" />
     <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests.csproj
@@ -11,8 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="3.4.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="3.4.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="4.2.1" />
+    <PackageReference Include="Hl7.FhirPath" Version="4.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
As per issue #175, this updates the Firely SDK in the core and test projects to the most recent stable release 4.2.1, up from 3.4.0. As such, all version references have been updated to 4.2.1, as well as some expected error messages for validation tests which changed from version 3.4.0 to 4.2.1.