### PR TITLE
Fix typo in R4 sample config file

### DIFF
--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool/configuration-sample.json
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool/configuration-sample.json
@@ -26,7 +26,7 @@
     {"path": "HealthcareService.availabilityExceptions", "method": "redact"},    
     {"path": "HealthcareService.extraDetails", "method": "redact"},   
     {"path": "HealthcareService.eligibility.comment", "method": "redact"},   
-    {"path": "HealthcareService.notAvaliable.description", "method": "redact"},
+    {"path": "HealthcareService.notAvailable.description", "method": "redact"},
     {"path": "Endpoint.name", "method": "redact"},
     {"path": "Endpoint.address", "method": "redact"},
     {"path": "Location.name", "method": "redact"},

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/r4-configuration-sample.json
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/r4-configuration-sample.json
@@ -25,7 +25,7 @@
     {"path": "HealthcareService.availabilityExceptions", "method": "redact"},    
     {"path": "HealthcareService.extraDetails", "method": "redact"},   
     {"path": "HealthcareService.eligibility.comment", "method": "redact"},   
-    {"path": "HealthcareService.notAvaliable.description", "method": "redact"},
+    {"path": "HealthcareService.notAvailable.description", "method": "redact"},
     {"path": "Endpoint.name", "method": "redact"},
     {"path": "Endpoint.address", "method": "redact"},
     {"path": "Location.name", "method": "redact"},

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.CommandLineTool/configuration-sample.json
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.CommandLineTool/configuration-sample.json
@@ -26,7 +26,7 @@
     {"path": "HealthcareService.eligibilityNote", "method": "redact"},    
     {"path": "HealthcareService.programName", "method": "redact"},    
     {"path": "HealthcareService.availabilityExceptions", "method": "redact"},   
-    {"path": "HealthcareService.notAvaliable.description", "method": "redact"},   
+    {"path": "HealthcareService.notAvailable.description", "method": "redact"},
     {"path": "Endpoint.name", "method": "redact"},
     {"path": "Endpoint.address", "method": "redact"},
     {"path": "Location.name", "method": "redact"},

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/stu3-configuration-sample.json
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/stu3-configuration-sample.json
@@ -25,7 +25,7 @@
     {"path": "HealthcareService.eligibilityNote", "method": "redact"},    
     {"path": "HealthcareService.programName", "method": "redact"},    
     {"path": "HealthcareService.availabilityExceptions", "method": "redact"},   
-    {"path": "HealthcareService.notAvaliable.description", "method": "redact"},   
+    {"path": "HealthcareService.notAvailable.description", "method": "redact"},   
     {"path": "Endpoint.name", "method": "redact"},
     {"path": "Endpoint.address", "method": "redact"},
     {"path": "Location.name", "method": "redact"},


### PR DESCRIPTION
Avaliable -> Available

I did check just in case it was a typo upstream, but no: https://www.hl7.org/fhir/healthcareservice-definitions.html#HealthcareService.notAvailable