### PR TITLE
Update Firely packages to 5.2

### DIFF
--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.R4" Version="5.0.0" />
-    <PackageReference Include="Hl7.Fhir.Base" Version="5.0.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="5.2.0" />
+    <PackageReference Include="Hl7.Fhir.Base" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core/Microsoft.Health.Fhir.Anonymizer.R4.Core.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core/Microsoft.Health.Fhir.Anonymizer.R4.Core.csproj
@@ -10,11 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="5.0.0" />
-    <PackageReference Include="Hl7.Fhir.Base" Version="5.0.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="5.2.0" />
+    <PackageReference Include="Hl7.Fhir.Base" Version="5.2.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.R4" Version="5.0.0" />
-	<PackageReference Include="Hl7.Fhir.Base" Version="5.0.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="5.2.0" />
+	<PackageReference Include="Hl7.Fhir.Base" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Validation/AttributeValidatorTests.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Validation/AttributeValidatorTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Validation
             var validationErrors = _validator.Validate(resource).ToList();
             Assert.Single(validationErrors);
 
-            var expectedError = "Element with minimum cardinality 1 cannot be null. At Task.IntentElement.";
+            var expectedError = "Element 'IntentElement' with minimum cardinality 1 cannot be null. At Task.IntentElement, line , position ";
             var actualError = validationErrors.FirstOrDefault()?.ErrorMessage;
             Assert.Equal(expectedError, actualError);
 

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Validation/AttributeValidatorTests.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Validation/AttributeValidatorTests.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Validation
         }
 
         [Theory]
-        [InlineData("******", "Value is not well-formatted Xml: Invalid Xml encountered. Details: Data at the root level is invalid. Line 1, position 1. At Patient.Text.Div.")]
-        [InlineData("Should not be valid", "Value is not well-formatted Xml: Invalid Xml encountered. Details: Data at the root level is invalid. Line 1, position 1. At Patient.Text.Div.")]
-        [InlineData("<body>Should not be valid</body>", "Value is not well-formed Xml adhering to the FHIR schema for Narrative: Root element of XHTML is not a <div> from the XHTML namespace (http://www.w3.org/1999/xhtml). At Patient.Text.Div.")]
-        [InlineData("<div xmlns='http://www.w3.org/1999/xhtml'><p>should not be valid<p></div>", "Value is not well-formatted Xml: Invalid Xml encountered. Details: The 'p' start tag on line 1 position 66 does not match the end tag of 'div'. Line 1, position 70. At Patient.Text.Div.")]
+        [InlineData("******", "Value is not well-formatted Xml: Invalid Xml encountered. Details: Data at the root level is invalid. Line 1, position 1. At Patient.Text.Div, line , position ")]
+        [InlineData("Should not be valid", "Value is not well-formatted Xml: Invalid Xml encountered. Details: Data at the root level is invalid. Line 1, position 1. At Patient.Text.Div, line , position ")]
+        [InlineData("<body>Should not be valid</body>", "Value is not well-formed Xml adhering to the FHIR schema for Narrative: Root element of XHTML is not a <div> from the XHTML namespace (http://www.w3.org/1999/xhtml). At Patient.Text.Div, line , position ")]
+        [InlineData("<div xmlns='http://www.w3.org/1999/xhtml'><p>should not be valid<p></div>", "Value is not well-formatted Xml: Invalid Xml encountered. Details: The 'p' start tag on line 1 position 66 does not match the end tag of 'div'. Line 1, position 70. At Patient.Text.Div, line , position ")]
         public void GivenAnInvalidNarrative_WhenValidateAResource_ThenValidationErrorsShouldBeReturned(string div, string expectedError)
         {
             var resource = new Patient

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Validation/AttributeValidatorTests.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Validation/AttributeValidatorTests.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Validation
         private readonly AttributeValidator _validator = new AttributeValidator();
 
         [Theory]
-        [InlineData("1+1", "'1+1' is not a correct literal for an id. At Patient.IdElement.Value.")]
-        [InlineData("1_1", "'1_1' is not a correct literal for an id. At Patient.IdElement.Value.")]
-        [InlineData("11|", "'11|' is not a correct literal for an id. At Patient.IdElement.Value.")]
-        [InlineData("00000000000000000000000000000000000000000000000000000000000000065", "'00000000000000000000000000000000000000000000000000000000000000065' is not a correct literal for an id. At Patient.IdElement.Value.")]
+        [InlineData("1+1", "'1+1' is not a correct literal for an id. At Patient.IdElement.Value, line , position ")]
+        [InlineData("1_1", "'1_1' is not a correct literal for an id. At Patient.IdElement.Value, line , position ")]
+        [InlineData("11|", "'11|' is not a correct literal for an id. At Patient.IdElement.Value, line , position ")]
+        [InlineData("00000000000000000000000000000000000000000000000000000000000000065", "'00000000000000000000000000000000000000000000000000000000000000065' is not a correct literal for an id. At Patient.IdElement.Value, line , position ")]
         public void GivenAnInvalidId_WhenValidateAResource_ThenValidationErrorsShouldBeReturned(string id, string expectedError)
         {
             var resource = new Patient

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests.csproj
@@ -11,8 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="5.0.0" />
-	<PackageReference Include="Hl7.Fhir.Base" Version="5.0.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="5.2.0" />
+	<PackageReference Include="Hl7.Fhir.Base" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.csproj
@@ -10,11 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.STU3" Version="5.0.0" />
-	<PackageReference Include="Hl7.Fhir.Base" Version="5.0.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="5.2.0" />
+	<PackageReference Include="Hl7.Fhir.Base" Version="5.2.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <Import Project="..\Microsoft.Health.Fhir.Anonymizer.Shared.Core\Microsoft.Health.Fhir.Anonymizer.Shared.Core.projitems" Label="Shared" />

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests.csproj
@@ -11,9 +11,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="5.0.0" />
-	<PackageReference Include="Hl7.Fhir.Base" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="5.2.0" />
+	<PackageReference Include="Hl7.Fhir.Base" Version="5.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">


### PR DESCRIPTION
This updates the Firely packages to 5.2.  This is to unblock the FHIR server which references this project to also move to the newer package.