### PR TITLE
Upgrade to dotnet 8

### DIFF
--- a/DICOM/src/Microsoft.Health.Anonymizer.Common.UnitTests/Microsoft.Health.Anonymizer.Common.UnitTests.csproj
+++ b/DICOM/src/Microsoft.Health.Anonymizer.Common.UnitTests/Microsoft.Health.Anonymizer.Common.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DICOM/src/Microsoft.Health.Anonymizer.Common/Microsoft.Health.Anonymizer.Common.csproj
+++ b/DICOM/src/Microsoft.Health.Anonymizer.Common/Microsoft.Health.Anonymizer.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <copyright>Copyright © Microsoft Corporation. All rights reserved.</copyright>
   </PropertyGroup>

--- a/DICOM/src/Microsoft.Health.Dicom.Anonymizer.CommandLineTool.UnitTests/Microsoft.Health.Dicom.Anonymizer.CommandLineTool.UnitTests.csproj
+++ b/DICOM/src/Microsoft.Health.Dicom.Anonymizer.CommandLineTool.UnitTests/Microsoft.Health.Dicom.Anonymizer.CommandLineTool.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/DICOM/src/Microsoft.Health.Dicom.Anonymizer.CommandLineTool/Microsoft.Health.Dicom.Anonymizer.CommandLineTool.csproj
+++ b/DICOM/src/Microsoft.Health.Dicom.Anonymizer.CommandLineTool/Microsoft.Health.Dicom.Anonymizer.CommandLineTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/DICOM/src/Microsoft.Health.Dicom.Anonymizer.Core.UnitTests/DicomUtilityTests.cs
+++ b/DICOM/src/Microsoft.Health.Dicom.Anonymizer.Core.UnitTests/DicomUtilityTests.cs
@@ -13,14 +13,26 @@ namespace Microsoft.Health.Dicom.Anonymizer.Core.UnitTests
 {
     public class DicomUtilityTests
     {
-        private static readonly TimeSpan _timeSpan = TimeSpan.FromHours(TimeZoneInfo.Local.GetUtcOffset(DateTime.Now).Hours);
+        /// <summary>
+        /// Gets the local time zone offset for a specific date.
+        /// This is critical for DICOM date parsing tests: the offset can vary depending on the date due to daylight saving time (DST) or historical time zone changes.
+        /// Using the offset for the test date (not DateTime.Now) ensures that expected DateTimeOffset values match the actual values produced by the parser,
+        /// regardless of when or where the tests are run.
+        /// </summary>
+        private static TimeSpan GetOffsetForDate(int year, int month, int day)
+        {
+            return TimeZoneInfo.Local.GetUtcOffset(new DateTime(year, month, day));
+        }
+
+        // IMPORTANT: Always use GetOffsetForDate for expected DateTimeOffset values in tests.
+        // This ensures correct handling of daylight saving time and local time zone changes for the date being tested.
 
         public static IEnumerable<object[]> GetValidDicomDateStringForParsing()
         {
-            yield return new object[] { "20210613", new DateTimeOffset(2021, 6, 13, 0, 0, 0, _timeSpan) };
-            yield return new object[] { "19900101", new DateTimeOffset(1990, 1, 1, 0, 0, 0, _timeSpan) };
-            yield return new object[] { "19691120", new DateTimeOffset(1969, 11, 20, 0, 0, 0, _timeSpan) };
-            yield return new object[] { "00010102", new DateTimeOffset(1, 1, 2, 0, 0, 0, _timeSpan) };
+            yield return new object[] { "20210613", new DateTimeOffset(2021, 6, 13, 0, 0, 0, GetOffsetForDate(2021, 6, 13)) };
+            yield return new object[] { "19900101", new DateTimeOffset(1990, 1, 1, 0, 0, 0, GetOffsetForDate(1990, 1, 1)) };
+            yield return new object[] { "19691120", new DateTimeOffset(1969, 11, 20, 0, 0, 0, GetOffsetForDate(1969, 11, 20)) };
+            yield return new object[] { "00010102", new DateTimeOffset(1, 1, 2, 0, 0, 0, GetOffsetForDate(1, 1, 2)) };
         }
 
         public static IEnumerable<object[]> GetValidDicomDateTimeStringForParsing()

--- a/DICOM/src/Microsoft.Health.Dicom.Anonymizer.Core.UnitTests/Microsoft.Health.Dicom.Anonymizer.Core.UnitTests.csproj
+++ b/DICOM/src/Microsoft.Health.Dicom.Anonymizer.Core.UnitTests/Microsoft.Health.Dicom.Anonymizer.Core.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/DICOM/src/Microsoft.Health.Dicom.Anonymizer.Core/Microsoft.Health.Dicom.Anonymizer.Core.csproj
+++ b/DICOM/src/Microsoft.Health.Dicom.Anonymizer.Core/Microsoft.Health.Dicom.Anonymizer.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Health.Dicom.Anonymizer.Core</RootNamespace>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <copyright>Copyright © Microsoft Corporation. All rights reserved.</copyright>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline.UnitTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline.UnitTests.csproj
@@ -1,15 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline/Microsoft.Health.Fhir.Anonymizer.R4.AzureDataFactoryPipeline.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="CommandLineParser" Version="2.7.82" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.24.1" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool/Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests.csproj
@@ -1,17 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Hl7.Fhir.R4" Version="5.11.3" />
-	<PackageReference Include="Hl7.Fhir.Base" Version="5.11.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+	<PackageReference Include="Hl7.Fhir.R4" Version="5.12.0" />
+	<PackageReference Include="Hl7.Fhir.Base" Version="5.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core/Microsoft.Health.Fhir.Anonymizer.R4.Core.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.Core/Microsoft.Health.Fhir.Anonymizer.R4.Core.csproj
@@ -2,18 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <copyright>Copyright © Microsoft Corporation. All rights reserved.</copyright>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="5.11.3" />
-    <PackageReference Include="Hl7.Fhir.Base" Version="5.11.3" />
-    <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
+    <PackageReference Include="Ensure.That" Version="10.1.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="5.12.0" />
+    <PackageReference Include="Hl7.Fhir.Base" Version="5.12.0" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests.csproj
@@ -1,18 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Hl7.Fhir.R4" Version="5.11.3" />
-	<PackageReference Include="Hl7.Fhir.Base" Version="5.11.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+	<PackageReference Include="Hl7.Fhir.R4" Version="5.12.0" />
+	<PackageReference Include="Hl7.Fhir.Base" Version="5.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.AzureDataFactoryPipeline/src/DataFactoryCustomActivity.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.AzureDataFactoryPipeline/src/DataFactoryCustomActivity.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Health.Fhir.Anonymizer.DataFactoryTool
 
             return options;
         });
-
         public ActivityInputData LoadActivityInput()
         {
             dynamic datasets = JsonConvert.DeserializeObject(File.ReadAllText(_datasetsConfigurationFile));

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline.UnitTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline.UnitTests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline/Microsoft.Health.Fhir.Anonymizer.Stu3.AzureDataFactoryPipeline.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   
@@ -15,8 +15,8 @@
   <Import Project="..\Microsoft.Health.Fhir.Anonymizer.Shared.AzureDataFactoryPipeline\Microsoft.Health.Fhir.Anonymizer.Shared.AzureDataFactoryPipeline.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="CommandLineParser" Version="2.7.82" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.24.1" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.CommandLineTool/Microsoft.Health.Fhir.Anonymizer.Stu3.CommandLineTool.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.CommandLineTool/Microsoft.Health.Fhir.Anonymizer.Stu3.CommandLineTool.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="5.11.3" />
-	<PackageReference Include="Hl7.Fhir.Base" Version="5.11.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+    <PackageReference Include="Hl7.Fhir.STU3" Version="5.12.0" />
+	<PackageReference Include="Hl7.Fhir.Base" Version="5.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.csproj
@@ -2,18 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <copyright>Copyright © Microsoft Corporation. All rights reserved.</copyright>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.STU3" Version="5.11.3" />
-	<PackageReference Include="Hl7.Fhir.Base" Version="5.11.3" />
-    <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
+    <PackageReference Include="Ensure.That" Version="10.1.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="5.12.0" />
+	<PackageReference Include="Hl7.Fhir.Base" Version="5.12.0" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests.csproj
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="5.11.3" />
-	<PackageReference Include="Hl7.Fhir.Base" Version="5.11.3" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="5.12.0" />
+	<PackageReference Include="Hl7.Fhir.Base" Version="5.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/docs/DICOM-anonymization.md
+++ b/docs/DICOM-anonymization.md
@@ -24,7 +24,7 @@ You can prepare your own DICOM files as input, or use sample DICOM files in fold
 
 ## Anonymize DICOM data: using the command line tool
 
-Once you have built the command line tool, you will find executable file Microsoft.Health.Dicom.Anonymizer.CommandLineTool.exe in the $SOURCE\DICOM\src\Microsoft.Health.Dicom.Anonymizer.CommandLineTool\bin\Debug|Release\net6.0 folder.
+Once you have built the command line tool, you will find executable file Microsoft.Health.Dicom.Anonymizer.CommandLineTool.exe in the $SOURCE\DICOM\src\Microsoft.Health.Dicom.Anonymizer.CommandLineTool\bin\Debug|Release\net8.0 folder.
 
 You can use this executable file to anonymize DICOM file.
 

--- a/docs/FHIR-anonymization.md
+++ b/docs/FHIR-anonymization.md
@@ -32,9 +32,9 @@ You can also export FHIR resource from your FHIR server using [Bulk Export](http
 ## Anonymize FHIR data: using the command line tool
 Once you have built the command line tool, you will find two executable files for R4 and STU3 respectively: 
 
-1. Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool.exe in the $SOURCE\FHIR\src\Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool\bin\Debug|Release\net6.0 folder. 
+1. Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool.exe in the $SOURCE\FHIR\src\Microsoft.Health.Fhir.Anonymizer.R4.CommandLineTool\bin\Debug|Release\net8.0 folder. 
 
-2. Microsoft.Health.Fhir.Anonymizer.Stu3.CommandLineTool.exe in the $SOURCE\FHIR\src\Microsoft.Health.Fhir.Anonymizer.Stu3.CommandLineTool\bin\Debug|Release\net6.0 folder.
+2. Microsoft.Health.Fhir.Anonymizer.Stu3.CommandLineTool.exe in the $SOURCE\FHIR\src\Microsoft.Health.Fhir.Anonymizer.Stu3.CommandLineTool\bin\Debug|Release\net8.0 folder.
 
  You can use these executables to anonymize FHIR resource files in a folder.   
 ```

--- a/release.yml
+++ b/release.yml
@@ -22,6 +22,12 @@ stages:
   jobs:
   - job: Build
     steps:
+    - task: UseDotNet@2
+      displayName: 'Use .NET 8 SDK'
+      inputs:
+        packageType: 'sdk'
+        version: '8.0.x'
+
     - task: DotNetCoreCLI@2
       displayName: 'dotnet build'
       inputs:


### PR DESCRIPTION
Updated DotNet from v6 to v8

Fixed unit test in FHIR where date was not shifted to the given timezone in date string (ShiftDateString)
Changed DicomUtilityTests to NOT use local time zone as this fails for users running it in different timezones (my case).

(This PR is the same as #242 just not a fork, testing build issues)